### PR TITLE
update phantomjs to use phantomjs-prebuilt

### DIFF
--- a/dev/package.json
+++ b/dev/package.json
@@ -43,7 +43,7 @@
     "karma-intl-shim": "^1.0.0",
     "karma-mocha": "^0.2.0",
     "karma-mocha-reporter": "^1.1.1",
-    "karma-phantomjs-launcher": "^0.2.0",
+    "karma-phantomjs-launcher": "^1.0.2",
     "karma-phantomjs-shim": "^1.0.0",
     "karma-safari-launcher": "^0.1.1",
     "karma-sourcemap-loader": "^0.3.7",

--- a/dev/package.json
+++ b/dev/package.json
@@ -53,7 +53,7 @@
     "mkdirp": "^0.5.1",
     "mocha": "^2.3.3",
     "nodemon": "^1.8.1",
-    "phantomjs": "^1.9.18",
+    "phantomjs-prebuilt": "^2.1.13",
     "postcss-cssnext": "^2.7.0",
     "postcss-import": "^8.1.2",
     "postcss-loader": "^0.11.1",


### PR DESCRIPTION
PhantomJS 1.9 is getting old.  The current is 2.1

It is also published as a different module now, changing from https://www.npmjs.com/package/phantomjs to https://www.npmjs.com/package/phantomjs-prebuilt but still supported by the same maintainers

This change was prompted by attemping to use the YARN client (https://yarnpkg.com) as an alternative to the NPM client on large projects, but PhantomJS won't install.  There is an issue discussing it here (https://github.com/yarnpkg/yarn/issues/987), and a recommendation to use `phantomjs-prebuilt`

This is something that people should test on a couple codebases though, phantomjs 2.0 updated Qt and Webkit (https://github.com/ariya/phantomjs/blob/master/ChangeLog).  I have not seen any problems yet.
