### PR TITLE
Output images to /images directory

### DIFF
--- a/config/webpack/partial/images.js
+++ b/config/webpack/partial/images.js
@@ -12,7 +12,7 @@ module.exports = function () {
         loaders: [{
           name: "images",
           test: /\.(jpe?g|png|gif|svg)$/i,
-          loader: fileLoader + "?limit=10000!" + isomorphicLoader
+          loader: fileLoader + "?name=/images/[name].[ext]&limit=10000!" + isomorphicLoader
         }]
       }
     });

--- a/config/webpack/partial/images.js
+++ b/config/webpack/partial/images.js
@@ -12,7 +12,7 @@ module.exports = function () {
         loaders: [{
           name: "images",
           test: /\.(jpe?g|png|gif|svg)$/i,
-          loader: fileLoader + "?name=/images/[name].[ext]&limit=10000!" + isomorphicLoader
+          loader: fileLoader + "?name=/images/[name]-[hash].[ext]&limit=10000!" + isomorphicLoader
         }]
       }
     });


### PR DESCRIPTION
To make it work with electrode-static-path generated route for images, I change the output directory of the images during build step to `output/images`.

This alone is not enough to make `generator-electrode` generated app to works out of the box on production environment, you need to change the directory for the images in `electrode-static-paths` to `js/images` because the default output dir for `generator-electrode` generated app is set to `dist/js`.