### PR TITLE
Allow webpack font loader to include font version

### DIFF
--- a/config/webpack/partial/fonts.js
+++ b/config/webpack/partial/fonts.js
@@ -13,12 +13,12 @@ module.exports = function () {
         loaders: [
           {
             name: "woff",
-            test: /\.woff(2)?$/i,
+            test: /\.(woff|woff2)(\?\S*)?$/i,
             loader: urlLoader + "?limit=10000&mimetype=application/font-woff!isomorphic"
           },
           {
             name: "fonts",
-            test: /\.(ttf|eot)$/i,
+            test: /\.(eot|ttf|svg)(\?\S*)?$/i,
             loader: fileLoader + "!isomorphic"
           }
         ]

--- a/config/webpack/partial/fonts.js
+++ b/config/webpack/partial/fonts.js
@@ -18,7 +18,7 @@ module.exports = function () {
           },
           {
             name: "fonts",
-            test: /\.(eot|ttf|svg)(\?\S*)?$/i,
+            test: /\.(eot|ttf)(\?\S*)?$/i,
             loader: fileLoader + "!isomorphic"
           }
         ]

--- a/config/webpack/partial/images.js
+++ b/config/webpack/partial/images.js
@@ -11,7 +11,7 @@ module.exports = function () {
       module: {
         loaders: [{
           name: "images",
-          test: /\.(jpe?g|png|gif|svg)$/i,
+          test: /\.(jpe?g|png|gif|svg)(\?\S*)?$/i,
           loader: fileLoader + "?limit=10000!" + isomorphicLoader
         }]
       }


### PR DESCRIPTION
When including fontAwesome css the parser failed to load the file due to the trailing version:
/~/font-awesome/fonts/fontawesome-webfont.eot?v=4.7.0

i.e.: Module parse failed: /home/lnaia/projects/frontendReboot/node_modules/font-awesome/fonts/fontawesome-webfont.eot?v=4.7.0 Unexpected character '�' (1:1)

After searching around, found a similar issue in https://github.com/webpack/less-loader/issues/53, where I took the regex from.