### PR TITLE
Add react/addons to webpack test config file

### DIFF
--- a/config/webpack/base-test.js
+++ b/config/webpack/base-test.js
@@ -42,7 +42,8 @@ var testConfig = {
     jsdom: "window",
     cheerio: "window",
     "react/lib/ExecutionEnvironment": true,
-    "react/lib/ReactContext": true
+    "react/lib/ReactContext": true,
+    "react/addons": true
   }
 };
 


### PR DESCRIPTION
When running tests w/ enzyme, I get the follow error:
```
ERROR in ./~/enzyme/build/react-compat.js
Module not found: Error: Cannot resolve module 'react/addons' in /projects/test/node_modules/enzyme/build
 @ ./~/enzyme/build/react-compat.js 37:16-39
```

After searching around I found the proposed solution referred here:
https://github.com/airbnb/enzyme/issues/302#issuecomment-207190560 and https://github.com/airbnb/enzyme/issues/503#issuecomment-258216960.

After adding that to the local _node_modules/electrode-archetype-react-app/config/webpack/base-test.js_ it works fine and as expected without any errors.