### PR TITLE
Use penthouse to automate critical CSS parsing

### DIFF
--- a/arch-gulpfile.js
+++ b/arch-gulpfile.js
@@ -7,6 +7,7 @@ const gulpHelper = archetype.devRequire("electrode-gulp-helper");
 const shell = gulpHelper.shell;
 const mkdirp = archetype.devRequire("mkdirp");
 const config = archetype.config;
+const penthouse = require("penthouse");
 
 function setupPath() {
   const nmBin = "node_modules/.bin";
@@ -130,6 +131,44 @@ function generateServiceWorker() {
     return false;
   }
 }
+
+function inlineCriticalCSS() {
+  const HOST = process.env.HOST || 'localhost';
+  const PORT = process.env.PORT || 3000;
+  const PATH = process.env.CRITICAL_PATH || '/';
+  const url = `http://${HOST}:${PORT}${PATH}`;
+  const PARSE_TIMEOUT = 2000 // How long to wait for the server to start
+  const statsPath = Path.resolve(process.cwd(), 'dist/server/stats.json');
+  const stats = JSON.parse(fs.readFileSync(statsPath));
+  const cssAsset = stats.assets.find(({ name }) => name.endsWith('.css'));
+  const cssAssetPath = Path.resolve(process.cwd(), `dist/js/${cssAsset.name}`);
+  const targetPath = Path.resolve(process.cwd(), 'dist/js/critical.css');
+  const penthouseOptions = {
+    url: url,
+    css: cssAssetPath,
+    width: 1440,
+    height: 900,
+    timeout: 30000,
+    strict: false,
+    maxEmbeddedBase64Length: 1000,
+    renderWaitTime: 2000,
+    blockJSRequests: false,
+  };
+  // Use setTimeout so the server has enough time to bind to the port
+  setTimeout(() => {
+    penthouse(penthouseOptions, (err, css )  => {
+        if (err) {
+          throw err;
+        }
+        fs.writeFile(targetPath, css, (err) => {
+          if (err) {
+            throw err;
+          }
+          process.exit(0);
+        })
+    });
+  }, PARSE_TIMEOUT);
+}
 /*
  *
  * For information on how to specify a task, see:
@@ -143,6 +182,7 @@ const tasks = {
   ".static-files-env": () => setStaticFilesEnv(),
   ".webpack-dev": () => setWebpackDev(),
   ".optimize-stats": () => setOptimizeStats(),
+  ".critical-css": () => inlineCriticalCSS(),
   "build": {
     desc: "Build your app's client bundle for production",
     task: ["build-dist"]
@@ -214,6 +254,10 @@ const tasks = {
   "hot": {
     desc: "Start server with watch in hot mode with webpack-dev-server",
     task: [".webpack-dev", ["server-hot", "server-watch", "generate-service-worker"]]
+  },
+  "critical-css": {
+    desc: "Start server and run penthouse to output critical CSS",
+    task: [["server", ".critical-css"]]
   },
   "generate-service-worker": {
     desc: "Generate Service Worker using the options provided in the app/config/sw-precache-config.json file for prod/dev/hot mode",

--- a/arch-gulpfile.js
+++ b/arch-gulpfile.js
@@ -8,6 +8,7 @@ const shell = gulpHelper.shell;
 const mkdirp = archetype.devRequire("mkdirp");
 const config = archetype.config;
 const penthouse = require("penthouse");
+const CleanCSS = require('clean-css');
 
 function setupPath() {
   const nmBin = "node_modules/.bin";
@@ -156,11 +157,12 @@ function inlineCriticalCSS() {
   };
   // Use setTimeout so the server has enough time to bind to the port
   setTimeout(() => {
-    penthouse(penthouseOptions, (err, css )  => {
+    penthouse(penthouseOptions, (err, css)  => {
         if (err) {
           throw err;
         }
-        fs.writeFile(targetPath, css, (err) => {
+        const minifiedCSS = new CleanCSS().minify(css).styles;
+        fs.writeFile(targetPath, minifiedCSS, (err) => {
           if (err) {
             throw err;
           }

--- a/dev/package.json
+++ b/dev/package.json
@@ -18,6 +18,7 @@
     "babel-loader": "^6.2.1",
     "chai": "^3.2.0",
     "chalk": "^1.1.1",
+    "clean-css": "^3.4.21",
     "css-loader": "^0.23.1",
     "electrode-bundle-analyzer": "^1.0.0",
     "electrode-electrify": "^1.0.0",

--- a/dev/package.json
+++ b/dev/package.json
@@ -54,6 +54,7 @@
     "mkdirp": "^0.5.1",
     "mocha": "^2.3.3",
     "nodemon": "^1.8.1",
+    "penthouse": "^0.10.3",
     "phantomjs-prebuilt": "^2.1.13",
     "postcss-cssnext": "^2.7.0",
     "postcss-import": "^8.1.2",


### PR DESCRIPTION
@ananavati @jmcriffey @donsalari 

Implements automated critical CSS parsing. Critical CSS will be outputted to `dist/js/critical.css`.  The gulp task technically runs the  `.critical-css` and `server` task in parallel, but we use a `setTimout`  of `2000ms` so that the server has a little time to bind to the port and all that before penthouse spins up and makes any requests.

We also set `renderWaitTime` to `2000ms`, which means it gives the page 2 seconds to load before attempting to parse any CSS. So this task will take at least 4 seconds to run.

related boilerplate pr: https://github.com/electrode-io/electrode-boilerplate-universal-react-node/pull/49