### PR TITLE
pwa build and run

### DIFF
--- a/arch-gulpfile.js
+++ b/arch-gulpfile.js
@@ -256,6 +256,10 @@ const tasks = {
   },
   "npm:test": ["check"],
   "npm:release": `node ${__dirname}/scripts/map-isomorphic-cdn.js`,
+  "pwa": {
+    desc: "PWA must have dist by running `gulp build` first and then start the app server only.",
+    task: `gulp build && gulp server`
+  },
   "server": {
     desc: "Start the app server only, Must have dist by running `gulp build` first.",
     task: `node server/index.js`


### PR DESCRIPTION
for service workers we need to gulp build first. it need the sw.js file in the dist.
This is because it doesn't work with webpack dev server right now: https://github.com/goldhand/sw-precache-webpack-plugin/issues/17