### PR TITLE
Fix hot during pwa 

### DIFF
--- a/config/webpack/partial/hot.js
+++ b/config/webpack/partial/hot.js
@@ -21,7 +21,7 @@ var getMultiBundleEntry = function (entries) {
 
 module.exports = function () {
   return function (config) {
-    var entry = config.__wmlMultiBundle ?
+    var entry = typeof config.entry === "object" ?
       getMultiBundleEntry(config.entry) :
       getDefaultEntry(config.entry);
 


### PR DESCRIPTION
@Aweary @ananavati 

This stops the hot command from crashing when PWA is active. I'll also have a PR that has the server actually read multiple custom bundles for https://github.com/electrode-io/electrode-boilerplate-universal-react-node.

Keep in mind this does not actually enable service workers in hot/dev mode, it simply keeps hot/dev mode from crashing. We will still need to address that issue.

related boilerplate pr https://github.com/electrode-io/electrode-boilerplate-universal-react-node/pull/50