### PR TITLE
show error while reading sw config

### DIFF
--- a/config/webpack/partial/pwa.js
+++ b/config/webpack/partial/pwa.js
@@ -8,16 +8,17 @@ var webAppManifestLoader = require.resolve("web-app-manifest-loader");
 var SWPrecacheWebpackPlugin = require("sw-precache-webpack-plugin");
 var FaviconsWebpackPlugin = require("favicons-webpack-plugin");
 var AddManifestFieldsPlugin = require('../plugins/add-manifest-fields');
-
 var swConfigPath = path.resolve(process.cwd(), "config/sw-config.js");
 
 function getSWConfig() {
-  var swConfig;
+  var swConfig = {};
 
-  try {
-    swConfig = require(swConfigPath);
-  } catch(err) {
-    swConfig = {};
+  if (fs.existsSync(swConfigPath)){
+    try {
+      swConfig = require(swConfigPath);
+    } catch(err) {
+      console.log("Error reading service worker config", err);
+    }
   }
 
   return swConfig;


### PR DESCRIPTION
display error if `sw-config.js` is present and invalid.
ex:

![screen shot 2016-12-06 at 16 42 09](https://cloud.githubusercontent.com/assets/4782871/20950217/35aac0d8-bbd3-11e6-9f2c-bb64e8d8c7fa.png)
