### PR TITLE
Add missing fs dependency

### DIFF
--- a/config/webpack/partial/pwa.js
+++ b/config/webpack/partial/pwa.js
@@ -1,4 +1,5 @@
 "use strict";
+var fs = require("fs");
 var path = require("path");
 var assign = require("lodash/assign");
 var archetype = require("../../archetype");


### PR DESCRIPTION
Looks like we're using `fs` in the `pwa.js` partial now, but we never imported it!

cc @ananavati 