### PR TITLE
Treat CSS inside node_modules as globals

### DIFF
--- a/config/webpack/partial/extract.js
+++ b/config/webpack/partial/extract.js
@@ -49,10 +49,18 @@ module.exports = function () {
 
     // By default, this archetype assumes you are using CSS-Modules + CSS-Next
     var loaders = [{
-      name: "extract-css",
+      name: "extract-css-modules",
       test: /\.css$/,
+      exclude: /node_modules/,
       loader: ExtractTextPlugin.extract(styleLoader, cssQuery)
     }];
+
+    loaders.push({
+      name: "extract-css-globals",
+      test: /\.css$/,
+      include: /node_modules/,
+      loader: ExtractTextPlugin.extract(styleLoader, cssQuery.replace('modules&', ''))
+    });
 
     if (!cssModuleSupport) {
       loaders.push({


### PR DESCRIPTION
...and everything else as local CSS modules

This should allow adding 3rd party css via npm (e.g. bootstrap, semantic-ui) and use them as global css modules. https://github.com/electrodejs/electrode-archetype-react-app/issues/54